### PR TITLE
fix: remove deprecated way to pass outputs

### DIFF
--- a/setup-alpine.sh
+++ b/setup-alpine.sh
@@ -324,5 +324,5 @@ rm .setup.sh
 endgroup
 #-----------------------------------------------------------------------
 
-echo "::set-output name=root-path::$rootfs_dir"
+echo "root-path=$rootfs_dir" >> $GITHUB_OUTPUT
 echo "$rootfs_dir/abin" >> $GITHUB_PATH


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/