### PR TITLE
Silence spurious error when checking for `binfmt-support` package

### DIFF
--- a/setup-alpine.sh
+++ b/setup-alpine.sh
@@ -197,7 +197,7 @@ if needs_emulator "$INPUT_ARCH"; then
 
 	# TODO: Consider replacing it with a simple shell script to speed-up
 	#  the installation.
-	if ! command -V update-binfmts >/dev/null; then
+	if ! command -V update-binfmts >/dev/null 2>&1; then
 		info 'Installing binfmt-support from Ubuntu repository'
 		apt-get install --no-install-recommends -y binfmt-support
 	fi


### PR DESCRIPTION
Fixes log message:

    ./setup-alpine.sh: line 200: command: update-binfmts: not found