### PR TITLE
Mount $GITHUB_WORKSPACE instead of $RUNNER_HOME/work

### DIFF
--- a/setup-alpine.sh
+++ b/setup-alpine.sh
@@ -283,7 +283,7 @@ mkdir -p proc
 mount -v -t proc none proc
 mount_bind /dev dev
 mount_bind /sys sys
-mount_bind "$RUNNER_HOME/work" "${RUNNER_HOME#/}/work"
+mount_bind "$GITHUB_WORKSPACE" "${RUNNER_HOME#/}/work"
 
 # Some systems (Ubuntu?) symlinks /dev/shm to /run/shm.
 if [ -L /dev/shm ] && [ -d /run/shm ]; then


### PR DESCRIPTION
This fixes some issues with `act`, which sets $GITHUB_WORKSPACE to the same path as the directory outside of the container rather than the default value of $RUNNER_HOME/work.

This should also fix a potential install failure when $GITHUB_WORKSPACE is customized by a workflow.