### PR TITLE
Don't assume workspace and tempdir are under `/home/$SUDO_USER`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -101,7 +101,9 @@ You can specify the source and destination path: `<src-dir>:<dest-dir>`.
 The `<src-dir>` is an absolute path of existing directory on the host system, `<dest-dir>` is an absolute path in the chroot (it will be created if doesn’t exist).
 You can omit the latter if they're the same.
 +
-Please note that _/home/runner/work_ (where’s your workspace located) is always mounted, don’t specify it here.
+Please note that _/home/runner/work_ (where your workspace and runner temp
+are located in GitHub's runner images) is always mounted if it exists, as
+are _$GITHUB_WORKSPACE_ and _$RUNNER_TEMP_; don’t specify them here.
 +
 Example: `${{ steps.alpine-aarch64.outputs.root-path }}:/mnt/alpine-aarch64`
 

--- a/action.yml
+++ b/action.yml
@@ -58,8 +58,9 @@ inputs:
       existing directory on the host system, `<dest-dir>` is an absolute path in the chroot
       (it will be created if doesn't exist). You can omit the latter if they're the same.
 
-      Please note that /home/runner/work (where's your workspace located) is always mounted,
-      don't specify it here.
+      Please note that /home/runner/work (where your workspace and runner temp
+      are located in GitHub's runner images) is always mounted if it exists,
+      as are $GITHUB_WORKSPACE and $RUNNER_TEMP; don’t specify them here.
     required: false
     default: ''
 outputs:

--- a/setup-alpine.sh
+++ b/setup-alpine.sh
@@ -18,8 +18,8 @@ readonly SCRIPT_PATH=$(readlink -f "$0")
 readonly SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 readonly ALPINE_BASE_PKGS='alpine-baselayout apk-tools busybox busybox-suid musl-utils'
-readonly RUNNER_HOME="/home/$SUDO_USER"
-readonly ROOTFS_BASE_DIR="$RUNNER_HOME/rootfs"
+readonly WORK_ROOT="/home/$SUDO_USER/work"
+readonly ROOTFS_BASE_DIR="/home/$SUDO_USER/rootfs"
 
 
 err_handler() {
@@ -283,7 +283,13 @@ mkdir -p proc
 mount -v -t proc none proc
 mount_bind /dev dev
 mount_bind /sys sys
-mount_bind "$RUNNER_HOME/work" "${RUNNER_HOME#/}/work"
+if [ -e "$WORK_ROOT" ]; then
+	# may not exist on third-party runner images
+	mount_bind "$WORK_ROOT" "${WORK_ROOT#/}"
+fi
+# redundant but harmless if these are inside $WORK_ROOT
+mount_bind "$GITHUB_WORKSPACE" "${GITHUB_WORKSPACE#/}"
+mount_bind "$RUNNER_TEMP" "${RUNNER_TEMP#/}"
 
 # Some systems (Ubuntu?) symlinks /dev/shm to /run/shm.
 if [ -L /dev/shm ] && [ -d /run/shm ]; then


### PR DESCRIPTION
Self-hosted runners, such as IBM's ppc64le and s390x runners, may put them somewhere else.  Put the rootfs under `$HOME/rootfs` (which should resolve to the same location as before) but use explicit bind mounts for `$GITHUB_WORKSPACE` and `$RUNNER_TEMP`.