### PR TITLE
Run armv7 and armhf without QEMU on aarch64 runners

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -57,7 +57,7 @@ Default: _see link:action.yml[]_
 
 [[arch]] arch::
 CPU architecture to emulate using https://www.qemu.org/docs/master/user/main.html[QEMU user space emulator].
-Allowed values are: `x86_64` (native), `x86` (native), `aarch64`, `armhf` footnote:[armhf is armv6 with hard-float.], `armv7`, `loongarch64` footnote:[loongarch64 is available since v3.21.], `ppc64le`, `riscv64` footnote:[riscv64 is available since v3.20.], and `s390x`.
+Allowed values are: `x86_64` (native on x86_64), `x86` (native on x86_64), `aarch64` (native on aarch64), `armhf` footnote:[armhf is armv6 with hard-float.] (native on aarch64), `armv7` (native on aarch64), `loongarch64` footnote:[loongarch64 is available since v3.21.], `ppc64le`, `riscv64` footnote:[riscv64 is available since v3.20.], and `s390x`.
 +
 Default: `x86_64`
 

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,10 @@ inputs:
     default: https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c
   arch:
     description: >
-      CPU architecture to emulate using QEMU. Allowed values are: `x86_64` (native), `x86` (native),
-      `aarch64`, `armhf` (armv6 with hard-float), `armv7`, `loongarch64` (available since v3.21), `ppc64le`, `riscv64` (available since v3.20), and `s390x`
+      CPU architecture to emulate using QEMU. Allowed values are: `x86_64` (native on x86_64),
+      `x86` (native on x86_64), `aarch64` (native on aarch64), `armhf` (armv6 with hard-float;
+      native on aarch64), `armv7` (native on aarch64), `loongarch64` (available since v3.21),
+      `ppc64le`, `riscv64` (available since v3.20), and `s390x`
     required: false
     default: x86_64
   branch:

--- a/setup-alpine.sh
+++ b/setup-alpine.sh
@@ -84,6 +84,7 @@ needs_emulator() {
 	local host="$(qemu_arch "$(uname -m)")"
 
 	[ "$target" = "$host" ] && return 1
+	[ "$host" = aarch64 ] && [ "$target" = arm ] && return 1
 	[ "$host" = x86_64 ] && [ "$target" = i386 ] && return 1
 	return 0
 }


### PR DESCRIPTION
setup-alpine runs aarch64 natively on GitHub's aarch64 runners if the caller passes an appropriate `apk-tools-url` and `arch`.  These runners can also natively run armv7 and armhf binaries, so skip QEMU there.

Broken out of #22.